### PR TITLE
Allow non-default site directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ deploydrupal_repo: ""
 # already deployed the latest code.
 deploydrupal_code: true
 
-# The branch that should be deployed by git.
+# The branch to be deployed by git.
 deploydrupal_version: "master"
 
 # Will discard any local changes present in the git repository.
@@ -21,6 +21,9 @@ deploydrupal_composer_no_dev_dependencies: true
 # The path the repository should be cloned to.
 deploydrupal_dir: "/var/www/html"
 deploydrupal_core_path: "{{ deploydrupal_dir }}/web"
+# The site name used by Drupal to look up settings and files on the file system.
+# ex. the "default" in `sites/default/files`.
+deploydrupal_site_name: "default"
 deploydrupal_files_become: false
 deploydrupal_files_path: "{{ deploydrupal_core_path }}/sites/default/files"
 deploydrupal_drush_path: "{{ deploydrupal_dir }}/vendor/bin/drush"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ deploydrupal_composer_no_dev_dependencies: true
 # The path the repository should be cloned to.
 deploydrupal_dir: "/var/www/html"
 deploydrupal_core_path: "{{ deploydrupal_dir }}/web"
+deploydrupal_files_become: false
 deploydrupal_files_path: "{{ deploydrupal_core_path }}/sites/default/files"
 deploydrupal_drush_path: "{{ deploydrupal_dir }}/vendor/bin/drush"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
     owner: "{{ deploydrupal_apache_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: 0770
+  become: "{{ deploydrupal_files_become }}"
 
 - name: open permissions on default directory.
   file:
@@ -75,6 +76,7 @@
     owner: "{{ deploydrupal_apache_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: 0770
+  become: "{{ deploydrupal_files_become }}"
 
 - name: clear drush cache.
   shell: "{{ deploydrupal_drush_path }} cache-clear drush"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: create files directory if it doesn't exist.
   file:
-    path: "{{ deploydrupal_files_path }}"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files"
     state: directory
     owner: "{{ deploydrupal_apache_user }}"
     group: "{{ deploydrupal_checkout_user }}"
@@ -10,7 +10,7 @@
 
 - name: open permissions on default directory.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/default"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
     state: directory
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
@@ -18,7 +18,7 @@
 
 - name: open permissions on settings file.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/default/settings.php"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/settings.php"
     state: file
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
@@ -55,7 +55,7 @@
 
 - name: close permissions on default directory.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/default"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
     state: directory
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
@@ -63,7 +63,7 @@
 
 - name: close permissions on settings file.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/default/settings.php"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/settings.php"
     state: file
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
@@ -71,7 +71,7 @@
 
 - name: update files directory owner and permissions.
   file:
-    path: "{{ deploydrupal_files_path }}"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files"
     state: directory
     owner: "{{ deploydrupal_apache_user }}"
     group: "{{ deploydrupal_checkout_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,12 +81,12 @@
 - name: clear drush cache.
   shell: "{{ deploydrupal_drush_path }} cache-clear drush"
   args:
-    chdir: "{{ deploydrupal_core_path }}"
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
 
 - name: run database updates.
   shell: "{{ deploydrupal_drush_path }} updatedb -y"
   args:
-    chdir: "{{ deploydrupal_core_path }}"
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
 
 # Import the latest configuration. This includes the latest
 # configuration_split configuration. Importing this twice ensures that the
@@ -95,7 +95,7 @@
 - name: import configuration 1/2.
   shell: "{{ deploydrupal_drush_path }} config-import -y"
   args:
-    chdir: "{{ deploydrupal_core_path }}"
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   register: drush_output
 
 - name: print drush output
@@ -104,7 +104,7 @@
 - name: import configuration 2/2.
   shell: "{{ deploydrupal_drush_path }} config-import -y"
   args:
-    chdir: "{{ deploydrupal_core_path }}"
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   register: drush_output
 
 - name: print drush output
@@ -122,7 +122,7 @@
 - name: clear caches.
   shell: "{{ deploydrupal_drush_path }} cache-rebuild"
   args:
-    chdir: "{{ deploydrupal_core_path }}"
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
 
 # Save redis data to disk. This is neccesary in Docker environments to ensure we
 # preserve the correct cache state.


### PR DESCRIPTION
Added `deploydrupal_site_name` to override "default" value.
Added `deploydrupal_files_become` to allow privilege escalation of files directory operations.