### PR TITLE
Fixed drush cr running on site-install instances.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,11 +87,15 @@
   shell: "{{ deploydrupal_drush_path }} cache-rebuild"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - not deploydrupal_site_install
 
 - name: run database updates.
   shell: "{{ deploydrupal_drush_path }} updatedb -y"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - not deploydrupal_site_install
 
 # site-install.
 - name: install site.


### PR DESCRIPTION
The steps I have appended conditionals to should only run when `deploydrupal_site_install` is `false` and be skipped otherwise as the database will be dropped/replaced in the subsequent site install section. Without this conditional check the deployment will likely break if there is no database there to begin with.