### PR TITLE
Run entity updates on Drupal deploy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,9 @@ deploydrupal_site_install_config: true
 # If set to false, drush config-import will not be run as part of deployment.
 deploydrupal_config_import: true
 
+# If set to false, drush entity-updates will not be run as part of deployment.
+deploydrupal_entity_updates: true
+
 # The path the repository should be cloned to.
 deploydrupal_dir: "/var/www/html"
 deploydrupal_core_path: "{{ deploydrupal_dir }}/web"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -133,6 +133,17 @@
 - name: print drush output
   debug: var=drush_output.stdout_lines
 
+- name: run entity updates.
+  shell: "{{ deploydrupal_drush_path}} entity-updates --yes"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  register: drush_output
+  when:
+  - deploydrupal_entity_updates
+
+- name: print drush output
+  debug: var=drush_output.stdout_lines
+
 - name: run npm theme build tasks.
   shell: "{{ item }}"
   args:


### PR DESCRIPTION
## Description

This adds the functionality to run `drush entity-updates` during the deployment process. This is to process any schema updates when an entity's base field definitions are changed. 

More information about entity update can be found here: https://www.drupal.org/docs/8/modules/entity-update