### PR TITLE
Run database updates after configuration import

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,13 +90,6 @@
   when:
     - not deploydrupal_site_install
 
-- name: run database updates.
-  shell: "{{ deploydrupal_drush_path }} updatedb -y"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - not deploydrupal_site_install
-
 # site-install.
 - name: install site.
   shell: "{{ deploydrupal_drush_path }} site-install {{ deploydrupal_site_install_config | ternary('--existing-config', '') }} --verbose --yes"
@@ -132,6 +125,13 @@
 
 - name: print drush output
   debug: var=drush_output.stdout_lines
+
+  - name: run database updates.
+  shell: "{{ deploydrupal_drush_path }} updatedb -y"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - not deploydrupal_site_install
 
 - name: run entity updates.
   shell: "{{ deploydrupal_drush_path}} entity-updates --yes"


### PR DESCRIPTION
Running database updates before configuration import can cause two potential issues:

1) Configuration changes made in hook_update_N() or post update hooks can be overwritten by configuration import.
2) Running hook_update_N() or post update hooks that rely on new configuration will fail.

There are no foreseen consequences changing the order of operations here. 