### PR TITLE
Use site name in files directory default.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ deploydrupal_core_path: "{{ deploydrupal_dir }}/web"
 # ex. the "default" in `sites/default/files`.
 deploydrupal_site_name: "default"
 deploydrupal_files_become: false
-deploydrupal_files_path: "{{ deploydrupal_core_path }}/sites/default/files"
+deploydrupal_files_path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files"
 deploydrupal_drush_path: "{{ deploydrupal_dir }}/vendor/bin/drush"
 
 deploydrupal_checkout_user: "jenkins"


### PR DESCRIPTION
I had already set `deploydrupal_site_name` variable to `mysitename` on recent project, and this was still defaulting to `default`. This caused an error with image style generation and the creation of folders within the `styles` directory. This change should set a more sensible default.