### PR TITLE
Adjust files directory sub-folder permissions after site install.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,3 +53,8 @@ deploydrupal_npm_theme_run_commands: []
 
 # Rebuild Drupal cache.
 deploydrupal_drush_cache_rebuild: true
+
+# Site file directory folders that need permission fixes after site install.
+deploydrupal_file_permission_fix_directories:
+  - 'styles'
+  - 'media-icons'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,15 +69,6 @@
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug-w
 
-- name: update files directory owner and permissions.
-  file:
-    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files"
-    state: directory
-    owner: "{{ deploydrupal_apache_user }}"
-    group: "{{ deploydrupal_checkout_user }}"
-    mode: 0770
-  become: "{{ deploydrupal_files_become }}"
-
 - name: clear drush cache.
   shell: "{{ deploydrupal_drush_path }} cache-clear drush"
   args:
@@ -105,9 +96,8 @@
     owner: "{{ deploydrupal_apache_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: 0770
-    recurse: yes
+    recurse: "{{ deploydrupal_site_install }}"
   become: "{{ deploydrupal_files_become }}"
-  when: deploydrupal_site_install_config
 
 # Import the latest configuration. This includes the latest
 # configuration_split configuration. Importing this twice ensures that the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     mode: 0770
   become: "{{ deploydrupal_files_become }}"
 
-- name: open permissions on default directory.
+- name: open permissions on site directory.
   file:
     path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
     state: directory
@@ -97,6 +97,17 @@
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:
     - deploydrupal_site_install
+
+- name: adjust files directory sub-folder permissions after site install.
+  file:
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files"
+    state: directory
+    owner: "{{ deploydrupal_apache_user }}"
+    group: "{{ deploydrupal_checkout_user }}"
+    mode: 0770
+    recurse: yes
+  become: "{{ deploydrupal_files_become }}"
+  when: deploydrupal_site_install_config
 
 # Import the latest configuration. This includes the latest
 # configuration_split configuration. Importing this twice ensures that the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,6 +107,8 @@
     mode: 0770
   become: "{{ deploydrupal_files_become }}"
   with_items: "{{ deploydrupal_file_permission_fix_directories }}"
+  when:
+    - deploydrupal_site_install
 
 # Import the latest configuration. This includes the latest
 # configuration_split configuration. Importing this twice ensures that the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,15 @@
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug-w
 
+- name: update files directory owner and permissions.
+  file:
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files"
+    state: directory
+    owner: "{{ deploydrupal_apache_user }}"
+    group: "{{ deploydrupal_checkout_user }}"
+    mode: 0770
+-  become: "{{ deploydrupal_files_become }}"
+
 - name: clear drush cache.
   shell: "{{ deploydrupal_drush_path }} cache-clear drush"
   args:
@@ -91,13 +100,13 @@
 
 - name: adjust files directory sub-folder permissions after site install.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files/{{ item }}"
     state: directory
     owner: "{{ deploydrupal_apache_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: 0770
-    recurse: "{{ deploydrupal_site_install }}"
   become: "{{ deploydrupal_files_become }}"
+  with_items: "{{ deploydrupal_file_permission_fix_directories }}"
 
 # Import the latest configuration. This includes the latest
 # configuration_split configuration. Importing this twice ensures that the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,7 +76,7 @@
     owner: "{{ deploydrupal_apache_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: 0770
--  become: "{{ deploydrupal_files_become }}"
+  become: "{{ deploydrupal_files_become }}"
 
 - name: clear drush cache.
   shell: "{{ deploydrupal_drush_path }} cache-clear drush"


### PR DESCRIPTION
The site install process was creating `sites/mysite/files/styles` and `sites/mysite/files/media-icons` and setting their ownership to the user who ran the site install, which was `root` in my case.

This fixes the ownership on those directories so image styles can be generated without an error (original impetus for this change).

After testing this I realized that we need to make this not perform the action on hidden files. `.htaccess` is being changed and it should not be. Fix for that to follow.

Current: `-rwxrwx--- 1 www-data root 543 Jan 16 21:54 .htaccess`
Correct: `-r--r--r-- 1 root     root 543 Jan 16 03:35 .htaccess`

I have thus far been unable to find a way to do this with the tools available.
* https://docs.ansible.com/ansible/latest/modules/file_module.html#examples