### PR TITLE
Use Drupal console to clear caches.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,7 @@ deploydrupal_site_name: "default"
 deploydrupal_files_become: false
 deploydrupal_files_path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/files"
 deploydrupal_drush_path: "{{ deploydrupal_dir }}/vendor/bin/drush"
+deploydrupal_drupal_path: "{{ deploydrupal_dir }}/vendor/bin/drupal"
 
 deploydrupal_checkout_user: "jenkins"
 deploydrupal_apache_user: "www-data"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -156,7 +156,7 @@
     - deploydrupal_npm_theme_path is defined
 
 - name: clear caches.
-  shell: "{{ deploydrupal_drush_path }} cache-rebuild"
+  shell: "{{ deploydrupal_drupal_path }} cache-rebuild"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:


### PR DESCRIPTION
We found that when enabling new modules via a configuration import with `drush cim` and leveraging plugins which the new modules provided in fields imported with the same import process, the `drush cr` following the config import would display an error.

For example:
```
In FieldStorageConfigStorage.php line 174:", 
        "                                                                               ", 
        "  Unable to determine class for field type 'daterange' found in the 'field.st  ", 
        "  orage.node.field_event_date' configuration                                   ", 
        "                                                                               ", 
        "", 
        "In DiscoveryTrait.php line 53:", 
        "                                                                               ", 
        "  The \"daterange\" plugin does not exist. Valid plugin IDs for Drupal\\Core\\Fie  ", 
        "  ld\\FieldTypePluginManager are: address, address_country, address_zone, comm  ", 
        "  ent, datetime, entity_reference_revisions, file, file_uri, image, layout_se  ", 
        "  ction, link, metatag, list_float, list_integer, list_string, path, telephon  ", 
        "  e, text, text_long, text_with_summary, published_at, boolean, changed, crea  ", 
        "  ted, decimal, email, entity_reference, float, integer, language, map, passw  ", 
        "  ord, string, string_long, timestamp, uri, uuid                               ", 
        "                                                                               ", 
        "", 
```
This was seen after enabling the `datetime_range` module.

We are doing further research to determine if this is related to our specific codebase, or is a deeper issue with [drush/drush](https://github.com/drush-ops/drush) and where a fix should made if one _should_ be made.

Once we determine that, we can move forward with this PR. 