### PR TITLE
Run database updates before config import.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,3 +61,6 @@ deploydrupal_drush_cache_rebuild: true
 deploydrupal_file_permission_fix_directories:
   - 'styles'
   - 'media-icons'
+
+# Run database updates before config is imported.
+deploydrupal_database_update_before_config_import: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,6 +117,7 @@
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:
     - not deploydrupal_site_install
+    - deploydrupal_database_update_before_config_import
 
 # Import the latest configuration. This includes the latest
 # configuration_split configuration. Importing this twice ensures that the
@@ -142,6 +143,14 @@
   register: drush_output
   when:
     - deploydrupal_config_import
+
+- name: run database updates.
+  shell: "{{ deploydrupal_drush_path }} updatedb -y"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - not deploydrupal_site_install
+    - not deploydrupal_database_update_before_config_import
 
 - name: print drush output
   debug: var=drush_output.stdout_lines

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,6 +144,9 @@
   when:
     - deploydrupal_config_import
 
+- name: print drush output
+  debug: var=drush_output.stdout_lines
+
 - name: run database updates.
   shell: "{{ deploydrupal_drush_path }} updatedb -y"
   args:
@@ -151,9 +154,6 @@
   when:
     - not deploydrupal_site_install
     - not deploydrupal_database_update_before_config_import
-
-- name: print drush output
-  debug: var=drush_output.stdout_lines
 
 - name: run theme build tasks.
   shell: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,6 +111,13 @@
   when:
     - deploydrupal_site_install
 
+- name: run database updates.
+  shell: "{{ deploydrupal_drush_path }} updatedb -y"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - not deploydrupal_site_install
+
 # Import the latest configuration. This includes the latest
 # configuration_split configuration. Importing this twice ensures that the
 # latter command enables and disables modules based upon the most up to date
@@ -138,13 +145,6 @@
 
 - name: print drush output
   debug: var=drush_output.stdout_lines
-
-- name: run database updates.
-  shell: "{{ deploydrupal_drush_path }} updatedb -y"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - not deploydrupal_site_install
 
 - name: run theme build tasks.
   shell: "{{ item }}"


### PR DESCRIPTION
We needed to fix a deployment issue on a site where we needed to run an update hook first to clear a chicken/egg situation. The first commit on this PR was a temporary work-around, I then reworked it to make this a configurable option.

This is untested at the moment, but wanted to run it by others to see if this was something we thought was valuable.
