### PR TITLE
Move cache clear for Drush.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,29 +79,22 @@
     mode: 0770
   become: "{{ deploydrupal_files_become }}"
 
-# See drush cache clear below for additional details.
-- name: clear caches.
-  shell: "{{ deploydrupal_drush_path }} cache-rebuild"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - deploydrupal_drush_cache_rebuild
-
-# Drush ^9 uses the Drupal service container. Clearing Drush cache before Drupal
-# cache can lead to fatal errors due to stale cache in the service container.
-- name: clear drush cache.
-  shell: "{{ deploydrupal_drush_path }} cache-clear drush"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - deploydrupal_drush_cache_rebuild
-
 - name: clear caches.
   shell: "{{ deploydrupal_drush_path }} cache-rebuild"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:
     - not deploydrupal_site_install
+
+# Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
+# cache before the Drush cache to avoid fatal errors due to stale cache in the
+# service container.
+- name: clear drush cache.
+  shell: "{{ deploydrupal_drush_path }} cache-clear drush"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_drush_cache_rebuild
 
 # site-install.
 - name: install site.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,7 @@
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:
     - not deploydrupal_site_install
+    - deploydrupal_drush_cache_rebuild
 
 # Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
 # cache before the Drush cache to avoid fatal errors due to stale cache in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,10 +79,22 @@
     mode: 0770
   become: "{{ deploydrupal_files_become }}"
 
+# See drush cache clear below for additional details.
+- name: clear caches.
+  shell: "{{ deploydrupal_drush_path }} cache-rebuild"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_drush_cache_rebuild
+
+# Drush ^9 uses the Drupal service container. Clearing Drush cache before Drupal
+# cache can lead to fatal errors due to stale cache in the service container.
 - name: clear drush cache.
   shell: "{{ deploydrupal_drush_path }} cache-clear drush"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_drush_cache_rebuild
 
 - name: clear caches.
   shell: "{{ deploydrupal_drush_path }} cache-rebuild"


### PR DESCRIPTION
> Drush 9 uses the Drupal service container. Clearing Drush cache before Drupal cache can lead to fatal errors due to stale cache in the service container.

This addresses that.

Closes gh-14.