### PR TITLE
Updated role to depend on drush deploy command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # Ansible Role: deploy-drupal
+
 Manages Drupal site deployments.
 
 ## Requirements
+
 None.
 
 ## Role Variables
+
 See [defaults](defaults/main.yml) for all available variables and accompanying
 documentation.
 
 ## Example Playbook
+
 Including an example of how to use your role (for instance, with variables
 passed in as parameters) is always nice for users too:
 
-```
+```yaml
     - hosts: all
 
       vars:
@@ -29,4 +33,5 @@ passed in as parameters) is always nice for users too:
 ```
 
 ## License
+
 MIT

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,9 @@ deploydrupal_npm_theme_build: false
 deploydrupal_npm_theme_path: ""
 deploydrupal_npm_theme_run_commands: []
 
+# Rebuild Drush cache.
+deploydrupal_drush_cache_rebuild: true
+
 # Site file directory folders that need permission fixes after site install.
 deploydrupal_file_permission_fix_directories:
   - 'styles'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,8 +29,8 @@ deploydrupal_site_install: false
 # deploydrupal_site_install is true.
 deploydrupal_site_install_config: true
 
-# If set to false, drush config-import will not be run as part of deployment.
-deploydrupal_config_import: true
+# If set to false, drush deploy will not be run as part of deployment.
+deploydrupal_drush_deploy: true
 
 # The path the repository should be cloned to.
 deploydrupal_dir: "/var/www/html"
@@ -53,9 +53,6 @@ deploydrupal_redis_host: ""
 deploydrupal_npm_theme_build: false
 deploydrupal_npm_theme_path: ""
 deploydrupal_npm_theme_run_commands: []
-
-# Rebuild Drupal cache.
-deploydrupal_drush_cache_rebuild: true
 
 # Site file directory folders that need permission fixes after site install.
 deploydrupal_file_permission_fix_directories:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,24 +79,6 @@
     mode: 0770
   become: "{{ deploydrupal_files_become }}"
 
-- name: clear caches.
-  shell: "{{ deploydrupal_drush_path }} cache-rebuild"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - not deploydrupal_site_install
-    - deploydrupal_drush_cache_rebuild
-
-# Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
-# cache before the Drush cache to avoid fatal errors due to stale cache in the
-# service container.
-- name: clear drush cache.
-  shell: "{{ deploydrupal_drush_path }} cache-clear drush"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - deploydrupal_drush_cache_rebuild
-
 # site-install.
 - name: install site.
   shell: "{{ deploydrupal_drush_path }} site-install {{ deploydrupal_site_install_config | ternary('--existing-config', '') }} --verbose --yes"
@@ -117,40 +99,18 @@
   when:
     - deploydrupal_site_install
 
-# Import the latest configuration. This includes the latest
-# configuration_split configuration. Importing this twice ensures that the
-# latter command enables and disables modules based upon the most up to date
-# configuration.
-- name: import configuration 1/2.
-  shell: "{{ deploydrupal_drush_path }} config-import -y"
+- name: drush deploy
+  shell: "{{ deploydrupal_drush_path }} deploy -v -y"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   register: drush_output
   when:
-    - deploydrupal_config_import
+    - deploydrupal_drush_deploy
 
 - name: print drush output
   debug: var=drush_output.stdout_lines
   when:
-    - deploydrupal_config_import
-
-- name: import configuration 2/2.
-  shell: "{{ deploydrupal_drush_path }} config-import -y"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  register: drush_output
-  when:
-    - deploydrupal_config_import
-
-- name: print drush output
-  debug: var=drush_output.stdout_lines
-
-- name: run database updates.
-  shell: "{{ deploydrupal_drush_path }} updatedb -y"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - not deploydrupal_site_install
+    - deploydrupal_drush_deploy
 
 - name: run theme build tasks.
   shell: "{{ item }}"
@@ -160,13 +120,6 @@
   when:
     - deploydrupal_npm_theme_build
     - deploydrupal_npm_theme_path is defined
-
-- name: clear caches.
-  shell: "{{ deploydrupal_drush_path }} cache-rebuild"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - deploydrupal_drush_cache_rebuild
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,15 @@
     mode: 0770
   become: "{{ deploydrupal_files_become }}"
 
+- name: run theme build tasks.
+  shell: "{{ item }}"
+  args:
+    chdir: "{{ deploydrupal_npm_theme_path }}"
+  with_items: "{{ deploydrupal_npm_theme_run_commands }}"
+  when:
+    - deploydrupal_npm_theme_build
+    - deploydrupal_npm_theme_path is defined
+
 # Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
 # cache before the Drush cache to avoid fatal errors due to stale cache in the
 # service container.
@@ -121,15 +130,6 @@
   debug: var=drush_output.stdout_lines
   when:
     - deploydrupal_drush_deploy
-
-- name: run theme build tasks.
-  shell: "{{ item }}"
-  args:
-    chdir: "{{ deploydrupal_npm_theme_path }}"
-  with_items: "{{ deploydrupal_npm_theme_run_commands }}"
-  when:
-    - deploydrupal_npm_theme_build
-    - deploydrupal_npm_theme_path is defined
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,16 @@
     mode: 0770
   become: "{{ deploydrupal_files_become }}"
 
+# Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
+# cache before the Drush cache to avoid fatal errors due to stale cache in the
+# service container.
+- name: clear drush cache.
+  shell: "{{ deploydrupal_drush_path }} cache-clear drush"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_drush_cache_rebuild
+
 # site-install.
 - name: install site.
   shell: "{{ deploydrupal_drush_path }} site-install {{ deploydrupal_site_install_config | ternary('--existing-config', '') }} --verbose --yes"


### PR DESCRIPTION
## Description
Updated role to depend on drush deploy command.

Requires drush 10.3 or later and would likely be tagged as a 2.0 release.

## Motivation / Context
https://github.com/drush-ops/drush/pull/4359

## Testing Instructions / How This Has Been Tested
Can be tested on CHQ with an update to drush.

## Documentation
Updated defaults yaml.
