### PR TITLE
Remove print drush output step.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,12 +122,6 @@
   shell: "{{ deploydrupal_drush_path }} deploy -v -y"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  register: drush_output
-  when:
-    - deploydrupal_drush_deploy
-
-- name: print drush output
-  debug: var=drush_output.stdout_lines
   when:
     - deploydrupal_drush_deploy
 


### PR DESCRIPTION
## Description
Remove "print drush output" step.

## Motivation / Context
drush output is already being displayed via the previous step and can be made more readable by using the [`yaml` callback plugin](https://www.jeffgeerling.com/blog/2018/use-ansibles-yaml-callback-plugin-better-cli-experience).

