### PR TITLE
Add cache clear before Drush cache clear.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,6 +88,9 @@
     - deploydrupal_npm_theme_build
     - deploydrupal_npm_theme_path is defined
 
+# Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
+# cache before the Drush cache to avoid fatal errors due to stale cache in the
+# service container.
 - name: clear caches.
   shell: "{{ deploydrupal_drush_path }} cache-rebuild"
   args:
@@ -95,9 +98,6 @@
   when:
     - deploydrupal_drush_cache_rebuild
 
-# Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
-# cache before the Drush cache to avoid fatal errors due to stale cache in the
-# service container.
 - name: clear drush cache.
   shell: "{{ deploydrupal_drush_path }} cache-clear drush"
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,6 +88,13 @@
     - deploydrupal_npm_theme_build
     - deploydrupal_npm_theme_path is defined
 
+- name: clear caches.
+  shell: "{{ deploydrupal_drush_path }} cache-rebuild"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_drush_cache_rebuild
+
 # Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
 # cache before the Drush cache to avoid fatal errors due to stale cache in the
 # service container.


### PR DESCRIPTION
## Description
Adds back in a cache clear that was removed in our conversion to using `drush deploy`.

https://github.com/ChromaticHQ/ansible-deploy-drupal/pull/25/files

We failed to heed our own advice.
```
# Drush ^9 uses the Drupal service container. We intentionally clear the Drupal
# cache before the Drush cache to avoid fatal errors due to stale cache in the
# service container.
```

## Motivation / Context
```
TASK [ansible-deploy-drupal : clear drush cache.] ******************************
Wednesday 09 September 2020  10:03:01 +0000 (0:01:41.890)       0:01:47.531 *** 
fatal: [localhost]: FAILED! => changed=true 
  cmd: /var/lib/tugboat/vendor/bin/drush cache-clear drush
  delta: '0:00:01.197608'
  end: '2020-09-09 10:03:02.627826'
  msg: non-zero return code
  rc: 1
  start: '2020-09-09 10:03:01.430218'
  stderr: |2-
     [error]  ArgumentCountError: Too few arguments to function Drupal\config_split\ConfigSplitCliService::__construct(), 12 passed in /var/lib/tugboat/web/core/lib/Drupal/Component/DependencyInjection/Container.php on line 259 and exactly 13 expected in Drupal\config_split\ConfigSplitCliService->__construct() (line 150 of /var/lib/tugboat/web/modules/contrib/config_split/src/ConfigSplitCliService.php) #0 /var/lib/tugboat/web/core/lib/Drupal/Component/DependencyInjection/Container.php(259): Drupal\config_split\ConfigSplitCliService->__construct(Object(Drupal\config_filter\Plugin\ConfigFilterPluginManager), Object(Drupal\config_filter\ConfigFilterStorageFactory), Object(Drupal\Core\Config\ConfigManager), Object(Drupal\Core\Config\CachedStorage), Object(Drupal\config_filter\Config\FilteredStorage), Object(Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher), Object(Drupal\redis\Lock\PhpRedis), Object(Drupal\Core\Config\TypedConfigManager), Object(Drupal\Core\Extension\ModuleHandler), Object(Drupal\Core\ProxyClass\Extension\ModuleInstaller), Object(Drupal\Core\Extension\ThemeHandler), Object(Drupal\Core\StringTranslation\TranslationManager))
```

## Testing Instructions / How This Has Been Tested
TK
