### PR TITLE
Config Sync Check Tool

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,4 +64,5 @@ deploydrupal_file_permission_fix_directories:
 
 # Config check. Useful for validating config in pre-production environments.
 deploydrupal_config_check_structure: false
+deploydrupal_config_check_structure_string: "active configuration is identical"
 deploydrupal_config_check_value: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,3 +61,7 @@ deploydrupal_drush_cache_rebuild: true
 deploydrupal_file_permission_fix_directories:
   - 'styles'
   - 'media-icons'
+
+# Config check. Useful for validating config in pre-production environments.
+deploydrupal_config_check_structure: false
+deploydrupal_config_check_value: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,4 +65,3 @@ deploydrupal_file_permission_fix_directories:
 # Config check. Useful for validating config in pre-production environments.
 deploydrupal_config_check_structure: false
 deploydrupal_config_check_structure_string: "active configuration is identical"
-deploydrupal_config_check_value: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,7 +137,7 @@
 # works because the exit code for grep is non-zero when the supplied search
 # string is not found.
 - name: config structure check
-  shell: "{{ deploydrupal_drush_path }} config:export -y | grep 'identical'"
+  shell: "{{ deploydrupal_drush_path }} config:export -y | grep {{ deploydrupal_config_check_structure_string }}"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,8 +144,8 @@
   when:
     - deploydrupal_config_check_structure
   failed_when: >
-    deploydrupal_config_check_structure_string in deploydrupal_config_check_result.stdout
-    or deploydrupal_config_check_structure_string in deploydrupal_config_check_result.stderr
+    deploydrupal_config_check_structure_string not in deploydrupal_config_check_result.stdout
+    or deploydrupal_config_check_structure_string not in deploydrupal_config_check_result.stderr
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,6 +142,8 @@
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:
     - deploydrupal_config_check_structure
+  fail:
+    msg: The tracked does not match the exported active config.
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,9 +143,7 @@
   register: deploydrupal_config_check_result
   when:
     - deploydrupal_config_check_structure
-  failed_when: >
-    deploydrupal_config_check_structure_string not in deploydrupal_config_check_result.stdout
-    or deploydrupal_config_check_structure_string not in deploydrupal_config_check_result.stderr
+  failed_when: "{{ deploydrupal_config_check_structure_string }} not in deploydrupal_config_check_result.stderr"
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,7 +137,7 @@
 # works because the exit code for grep is non-zero when the supplied search
 # string is not found.
 - name: config structure check
-  shell: "{{ deploydrupal_drush_path }} config:export -y | grep {{ deploydrupal_config_check_structure_string }}"
+  shell: "{{ deploydrupal_drush_path }} config:export -y | grep '{{ deploydrupal_config_check_structure_string }}'"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,7 +143,7 @@
   register: deploydrupal_config_check_result
   when:
     - deploydrupal_config_check_structure
-  failed_when: "{{ deploydrupal_config_check_structure_string }} not in deploydrupal_config_check_result.stderr"
+  failed_when: "deploydrupal_config_check_structure_string not in deploydrupal_config_check_result.stderr"
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -128,10 +128,15 @@
 # Config Value Check - This is primarily to catch configuration value updates
 # done via update hooks from Dependabot PR's. This is to replace the dev process
 # that would be done in a local environment.
+- name: config value check update
+  shell: "{{ deploydrupal_drush_path }} updatedb -y"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_config_check_value
+
 - name: config value check
-  shell: |
-    "{{ deploydrupal_drush_path }} updatedb -y"
-    "{{ deploydrupal_drush_path }} config:export -y | grep 'identical'"
+  shell: "{{ deploydrupal_drush_path }} config:export -y | grep 'identical'"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,8 +142,6 @@
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:
     - deploydrupal_config_check_structure
-  fail:
-    msg: The tracked does not match the exported active config.
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,7 +137,7 @@
 # works because the exit code for grep is non-zero when the supplied search
 # string is not found.
 - name: config structure check
-  shell: "{{ deploydrupal_drush_path }} config:export -y 3>&1 1>&2 2>&3 | grep '{{ deploydrupal_config_check_structure_string }}'"
+  shell: "{{ deploydrupal_drush_path }} config:export -y 2>&1 | grep '{{ deploydrupal_config_check_structure_string }}'"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,23 +125,6 @@
   when:
     - deploydrupal_site_install
 
-# Config Value Check - This is primarily to catch configuration value updates
-# done via update hooks from Dependabot PR's. This is to replace the dev process
-# that would be done in a local environment.
-- name: config value check update
-  shell: "{{ deploydrupal_drush_path }} updatedb -y"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - deploydrupal_config_check_value
-
-- name: config value check
-  shell: "{{ deploydrupal_drush_path }} config:export -y | grep 'identical'"
-  args:
-    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
-  when:
-    - deploydrupal_config_check_value
-
 - name: drush deploy
   shell: "{{ deploydrupal_drush_path }} deploy -v -y"
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,11 +137,15 @@
 # works because the exit code for grep is non-zero when the supplied search
 # string is not found.
 - name: config structure check
-  shell: "{{ deploydrupal_drush_path }} config:export -y 3>&1 1>&2 2>&3 | grep '{{ deploydrupal_config_check_structure_string }}'"
+  shell: "{{ deploydrupal_drush_path }} config:export -y"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  register: deploydrupal_config_check_result
   when:
     - deploydrupal_config_check_structure
+  failed_when: >
+    deploydrupal_config_check_structure_string in deploydrupal_config_check_result.stdout
+    or deploydrupal_config_check_structure_string in deploydrupal_config_check_result.stderr
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,7 +137,7 @@
 # works because the exit code for grep is non-zero when the supplied search
 # string is not found.
 - name: config structure check
-  shell: "{{ deploydrupal_drush_path }} config:export -y 2>&1 | grep '{{ deploydrupal_config_check_structure_string }}'"
+  shell: "{{ deploydrupal_drush_path }} config:export -y 3>&1 1>&2 2>&3 | grep '{{ deploydrupal_config_check_structure_string }}'"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,12 +125,33 @@
   when:
     - deploydrupal_site_install
 
+# Config Value Check - This is primarily to catch configuration value updates
+# done via update hooks from Dependabot PR's. This is to replace the dev process
+# that would be done in a local environment.
+- name: config value check
+  shell: |
+    "{{ deploydrupal_drush_path }} updatedb -y"
+    "{{ deploydrupal_drush_path }} config-export | grep 'identical'"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_config_check_value
+
 - name: drush deploy
   shell: "{{ deploydrupal_drush_path }} deploy -v -y"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:
     - deploydrupal_drush_deploy
+
+# Config Structure Check - This is primarily to catch configuration structure
+# changes from updating modules with Dependabot or missed configuration.
+- name: config structure check
+  shell: "{{ deploydrupal_drush_path }} config-export -y | grep 'identical'"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_config_check_structure
 
 # Save redis data to disk. This is necessary in Docker environments to ensure we
 # preserve the correct cache state.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -133,7 +133,9 @@
     - deploydrupal_drush_deploy
 
 # Config Structure Check - This is primarily to catch configuration structure
-# changes from updating modules with Dependabot or missed configuration.
+# changes from updating modules with Dependabot or missed configuration. This
+# works because the exit code for grep is non-zero when the supplied search
+# string is not found.
 - name: config structure check
   shell: "{{ deploydrupal_drush_path }} config:export -y | grep 'identical'"
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -131,7 +131,7 @@
 - name: config value check
   shell: |
     "{{ deploydrupal_drush_path }} updatedb -y"
-    "{{ deploydrupal_drush_path }} config-export -y | grep 'identical'"
+    "{{ deploydrupal_drush_path }} config:export -y | grep 'identical'"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:
@@ -147,7 +147,7 @@
 # Config Structure Check - This is primarily to catch configuration structure
 # changes from updating modules with Dependabot or missed configuration.
 - name: config structure check
-  shell: "{{ deploydrupal_drush_path }} config-export -y | grep 'identical'"
+  shell: "{{ deploydrupal_drush_path }} config:export -y | grep 'identical'"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,7 +137,7 @@
 # works because the exit code for grep is non-zero when the supplied search
 # string is not found.
 - name: config structure check
-  shell: "{{ deploydrupal_drush_path }} config:export -y | grep '{{ deploydrupal_config_check_structure_string }}'"
+  shell: "{{ deploydrupal_drush_path }} config:export -y 2>&1 | grep '{{ deploydrupal_config_check_structure_string }}'"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,10 +132,8 @@
   when:
     - deploydrupal_drush_deploy
 
-# Config Structure Check - This is primarily to catch configuration structure
-# changes from updating modules with Dependabot or missed configuration. This
-# works because the exit code for grep is non-zero when the supplied search
-# string is not found.
+# Identify Drupal configuration changes in core or contrib updates that need
+# to be exported and may have been missed.
 - name: config structure check
   shell: "{{ deploydrupal_drush_path }} config:export -y"
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -131,7 +131,7 @@
 - name: config value check
   shell: |
     "{{ deploydrupal_drush_path }} updatedb -y"
-    "{{ deploydrupal_drush_path }} config-export | grep 'identical'"
+    "{{ deploydrupal_drush_path }} config-export -y | grep 'identical'"
   args:
     chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
   when:


### PR DESCRIPTION
## Description

We want to detect config structure ~~_and_ config value~~ changes in our PR's before they are deployed.

## Proposed Solution

Leverage the work already started in this PR:
- https://github.com/ChromaticHQ/chromatichq.com/pull/2549

Create ~~two~~ one new step, which will fail the build if it does not perform as expected.

### Config Structure Check

This is primarily to catch config structure changes from updating modules with Dependabot or missed config.
1. Import config (`drush cim`)
1. Export config (`drush cex`)
1. Check for config diff
1. If a diff exists, fail the build.

## Motivation / Context
We don't want to revert ~~config value changes done in update hook or allow~~ config structure to deviate from the tracked code.

## Testing Instructions / How This Has Been Tested
I need to figure out some good test cases. Most PR's should continue to pass as normal. I need to "break" some config and verify both cases fail a build.

The variables that control this should _only_ be set to `true` in pre-production environments.

## Screenshots
TK

## Remaining Tasks
- [x] Document grep exit code fanciness.
- [x] Document why we can't check config value.
- [x] Increase length of grep string that is matched.
- [x] Determine if a config value check is feasible.



---

_The config value check was deemed out of scope in this effort due to the high level of complexity and effort it would require to properly perform it._

### Config Value Check
This is primarily to catch config value updates done via update hooks from Dependabot PR's. This is to replace the dev process that would be done in a local environment.

1. Import config to get it in sync with the branch (`drush cim`)
1. Run database updates (`drush updb`)
1. Export config (`drush cex`)
1. Check for config diff
1. If a diff exists, fail the build.
1. Otherwise reset database to run steps in correct order (this is the issue/blocker).
1. Run normal deployment steps (`drush deploy`)

I had to remove my config value check. [`eb4ecb6` (#28)](https://github.com/ChromaticHQ/ansible-deploy-drupal/pull/28/commits/eb4ecb6e19677bce588221e719888269c3c81760)

We need to run `updatedb` and _not_ run `config:import` first, as `config:import` could blow away the changes done by `updatedb`. However, without importing config, the subsequent `config:export` diff will include the full diff between the current state of the branch and the DB when it was last imported. That diff will often include more than the changes done by any update hooks. The only way around this is to:

1. Run database config import to get database in sync with config changes in the current branch. (`drush cim`)
1. run `updatedb`

However, this goes against the suggested order of the commands in `drush deploy` and may cause issues as there is now a delta between our deployment process on Tugboat and what we do on production.