### PR TITLE
Alter permissions for all settings files.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,5 +66,5 @@ deploydrupal_file_permission_fix_directories:
 deploydrupal_config_check_structure: false
 deploydrupal_config_check_structure_string: "active configuration is identical"
 
-# The pattern used to match settings files that need have permissions changed.
+# The pattern used to match settings files that need permissions changed.
 deploydrupal_settings_file_pattern: "settings*.php"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,3 +65,6 @@ deploydrupal_file_permission_fix_directories:
 # Config check. Useful for validating config in pre-production environments.
 deploydrupal_config_check_structure: false
 deploydrupal_config_check_structure_string: "active configuration is identical"
+
+# The pattern used to match settings files that need have permissions changed.
+deploydrupal_settings_file_pattern: "settings.*.php"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,4 +67,4 @@ deploydrupal_config_check_structure: false
 deploydrupal_config_check_structure_string: "active configuration is identical"
 
 # The pattern used to match settings files that need have permissions changed.
-deploydrupal_settings_file_pattern: "settings.*.php"
+deploydrupal_settings_file_pattern: "settings*.php"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,11 +18,13 @@
 
 - name: open permissions on settings file.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/settings.php"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/"
     state: file
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug+w
+  with_fileglob:
+    - "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/{{ deploydrupal_settings_file_pattern }}"
 
 - name: get latest code.
   git:
@@ -64,11 +66,13 @@
 
 - name: close permissions on settings file.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/settings.php"
+    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/"
     state: file
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug-w
+  with_fileglob:
+    - "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/{{ deploydrupal_settings_file_pattern }}"
 
 - name: update files directory owner and permissions.
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug+w
 
-- name: discover settings files.
+- name: discover settings files in all /sites directories.
   find:
     paths: "{{ deploydrupal_core_path }}/sites"
     patterns: "{{ deploydrupal_settings_file_pattern }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,12 +26,12 @@
 
 - name: open permissions on settings files.
   file:
-    path: "{{ settings_file }}"
+    path: "{{ settings_file.path }}"
     state: file
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug+w
-  loop: "{{ deploydrupal_settings_files }}"
+  loop: "{{ deploydrupal_settings_files.files }}"
   loop_control:
     loop_var: settings_file
 
@@ -75,12 +75,12 @@
 
 - name: close permissions on settings files.
   file:
-    path: "{{ settings_file }}"
+    path: "{{ settings_file.path }}"
     state: file
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug-w
-  loop: "{{ deploydrupal_settings_files }}"
+  loop: "{{ deploydrupal_settings_files.files }}"
   loop_control:
     loop_var: settings_file
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,15 +16,24 @@
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug+w
 
-- name: open permissions on settings file.
+- name: discover settings files.
+  find:
+    paths: "{{ deploydrupal_core_path }}/sites"
+    patterns: "{{ deploydrupal_settings_file_pattern }}"
+    depth: 2
+    recurse: true
+  register: deploydrupal_settings_files
+
+- name: open permissions on settings files.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/"
+    path: "{{ settings_file }}"
     state: file
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug+w
-  with_fileglob:
-    - "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/{{ deploydrupal_settings_file_pattern }}"
+  loop: "{{ deploydrupal_settings_files }}"
+  loop_control:
+    loop_var: settings_file
 
 - name: get latest code.
   git:
@@ -64,15 +73,16 @@
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug-w
 
-- name: close permissions on settings file.
+- name: close permissions on settings files.
   file:
-    path: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/"
+    path: "{{ settings_file }}"
     state: file
     owner: "{{ deploydrupal_checkout_user }}"
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug-w
-  with_fileglob:
-    - "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}/{{ deploydrupal_settings_file_pattern }}"
+  loop: "{{ deploydrupal_settings_files }}"
+  loop_control:
+    loop_var: settings_file
 
 - name: update files directory owner and permissions.
   file:


### PR DESCRIPTION
## Description
Closes GH-9.

Aims to set restrictive file permissions on all settings files, not just `settings.php`.

This is simply a prototype that untested. I'm guessing others will have ideas on how to do this in a clean "Ansible" way.

## Motivation / Context
We want to set correct permissions on all settings files.

## Testing Instructions / How This Has Been Tested

Tested in this PR: https://github.com/ChromaticHQ/chromatichq.com/pull/2540

All settings files now have the same/correct permissions.
```
root@apache-php7:/var/lib/tugboat# cd web/sites/default/
root@apache-php7:/var/lib/tugboat/web/sites/default# ls -la
total 96
dr-xr-xr-x 3 root     root   226 Sep  8 13:07 .
drwxr-xr-x 3 root     root   130 Sep  8 13:07 ..
-rw-r--r-- 1 root     root  6762 Sep  8 13:07 default.services.yml
-rw-r--r-- 1 root     root 31870 Sep  8 13:07 default.settings.php
drwxrwx--- 2 www-data root     6 Sep  8 13:07 files
-rw-r--r-- 1 root     root  5560 Sep  8 13:04 services.yml
-r--r--r-- 1 root     root  1857 Sep  8 13:04 settings.lando.php
-r--r--r-- 1 root     root 27847 Sep  8 13:04 settings.php
-r--r--r-- 1 root     root  6237 Sep  8 13:04 settings.platformsh.php
-r--r--r-- 1 root     root  2080 Sep  8 13:04 settings.redis.php
-r--r--r-- 1 root     root  1038 Sep  8 13:04 settings.tugboat.php
```

## Documentation
Yes, and I added it.
