### PR TITLE
Add second config import.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -146,6 +146,17 @@
   when:
     - deploydrupal_drush_deploy
 
+# Import the latest configuration again. This includes the latest
+# configuration_split configuration. Importing this twice ensures that the
+# latter command enables and disables modules based upon the most up to date
+# configuration.
+- name: drush config import
+  shell: "{{ deploydrupal_drush_path }} config:import -y"
+  args:
+    chdir: "{{ deploydrupal_core_path }}/sites/{{ deploydrupal_site_name }}"
+  when:
+    - deploydrupal_drush_deploy
+
 # Identify Drupal configuration changes in core or contrib updates that need
 # to be exported and may have been missed.
 - name: config structure check

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -149,7 +149,8 @@
 # Import the latest configuration again. This includes the latest
 # configuration_split configuration. Importing this twice ensures that the
 # latter command enables and disables modules based upon the most up to date
-# configuration.
+# configuration. Additional information and discussion can be found here:
+# https://github.com/drush-ops/drush/issues/2449#issuecomment-708655673
 - name: drush config import
   shell: "{{ deploydrupal_drush_path }} config:import -y"
   args:


### PR DESCRIPTION
## Description
Adds an additional config import step to resolve cases where new config splits are created. With the addition of the config checking step, we recently had a PR fail until I pointed it to this branch for the deployment.

I'm guessing this will spark some discussion, but I wanted to at least get a PR created to begin the conversation.

## Motivation / Context
We need to get config fully in sync in one deployment.

## Testing Instructions / How This Has Been Tested
PR's build without issue when pointed to this branch, and fail previously.