### PR TITLE
Fixed failure when a settings file is removed during deploy.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,6 +73,14 @@
     group: "{{ deploydrupal_checkout_user }}"
     mode: ug-w
 
+- name: rediscover settings files in all /sites directories in case of settings file changes.
+  find:
+    paths: "{{ deploydrupal_core_path }}/sites"
+    patterns: "{{ deploydrupal_settings_file_pattern }}"
+    depth: 2
+    recurse: true
+  register: deploydrupal_settings_files
+
 - name: close permissions on settings files.
   file:
     path: "{{ settings_file.path }}"


### PR DESCRIPTION

## Description
Fixed failure when a settings file is removed during deploy.

Added a step to "rediscover" the settings files after code changes have
been pulled.

## Motivation / Context
Closes #33

## Testing Instructions / How This Has Been Tested
Tested on internal project.
